### PR TITLE
Fix links

### DIFF
--- a/docs/ui-guide.md
+++ b/docs/ui-guide.md
@@ -106,4 +106,4 @@ binascii.Error: Non-hexadecimal digit found
 
 This means BinSync crashed while trying to commit something. Many things could have gone wrong here. Often the easiest way to fix this is just restarting your decompiler (so you can reload BinSync).
 
-If possible, copy the **full** stack trace with the error that likely came right before this error (which caused it), and file an [Issue](https://github.com/angr/binsync/issues).
+If possible, copy the **full** stack trace with the error that likely came right before this error (which caused it), and [file an issue](https://github.com/binsync/binsync/issues).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -30,13 +30,13 @@ const config = {
       ({
         docs: {
           sidebarPath: './sidebars.js',
-          editUrl: 'https://github.com/binsync/docs.binsync.net',
+          editUrl: 'https://github.com/binsync/docs.binsync.net/tree/main',
           routeBasePath: '/',
         },
         blog: {
           showReadingTime: true,
           feedOptions: { type: ['rss', 'atom'], xslt: true },
-          editUrl: 'https://github.com/binsync/docs.binsync.net',
+          editUrl: 'https://github.com/binsync/docs.binsync.net/tree/main',
           onInlineTags: 'warn',
           onInlineAuthors: 'warn',
           onUntruncatedBlogPosts: 'warn',


### PR DESCRIPTION
Fix `editUrl`s so Edit links in page footers no longer return 404s. 

Fix link to BinSync's issues page to point to the new repo location. The old link still works, but there's no guarantee it works forever. 